### PR TITLE
Stateful solution class & Dead Thread fix

### DIFF
--- a/code-runner/pom.xml
+++ b/code-runner/pom.xml
@@ -101,12 +101,12 @@
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--<dependency>-->
-            <!--<groupId>org.awaitility</groupId>-->
-            <!--<artifactId>awaitility</artifactId>-->
-            <!--<version>3.1.0</version>-->
-            <!--<scope>test</scope>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/code-runner/src/main/java/com/epam/coderunner/model/CompiledTask.java
+++ b/code-runner/src/main/java/com/epam/coderunner/model/CompiledTask.java
@@ -2,6 +2,7 @@ package com.epam.coderunner.model;
 
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -9,16 +10,16 @@ public final class CompiledTask implements RequestSignature{
     private final String userId;
     private final long taskId;
     private final Map<String, String> inputOutputs;
-    private final Function<String, String> function;
+    private final Supplier<Function<String, String>> functionSupplier;
 
     public CompiledTask(final String userId,
                         final long taskId,
                         final Map<String, String> inputOutputs,
-                        final Function<String, String> function) {
+                        final Supplier<Function<String, String>> functionSupplier) {
         this.userId = userId;
         this.taskId = taskId;
         this.inputOutputs = checkNotNull(inputOutputs);
-        this.function = checkNotNull(function);
+        this.functionSupplier = checkNotNull(functionSupplier);
     }
 
     public String getUserId() {
@@ -31,6 +32,6 @@ public final class CompiledTask implements RequestSignature{
         return inputOutputs;
     }
     public Function<String, String> getFunction() {
-        return function;
+        return functionSupplier.get();
     }
 }

--- a/code-runner/src/main/java/com/epam/coderunner/model/TestingStatus.java
+++ b/code-runner/src/main/java/com/epam/coderunner/model/TestingStatus.java
@@ -1,11 +1,8 @@
 package com.epam.coderunner.model;
 
 import com.epam.coderunner.InternalUtils;
-import com.google.common.base.Throwables;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 
 public final class TestingStatus {
 

--- a/code-runner/src/main/java/com/epam/coderunner/model/TestingStatus.java
+++ b/code-runner/src/main/java/com/epam/coderunner/model/TestingStatus.java
@@ -1,6 +1,6 @@
 package com.epam.coderunner.model;
 
-import com.epam.coderunner.InternalUtils;
+import com.epam.coderunner.support.InternalUtils;
 
 import java.util.Collection;
 

--- a/code-runner/src/main/java/com/epam/coderunner/model/TestingStatusBuilder.java
+++ b/code-runner/src/main/java/com/epam/coderunner/model/TestingStatusBuilder.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 public class TestingStatusBuilder {
-    private Collection<Status> testsStatuses = new ArrayList<>(20);
+    private final Collection<Status> testsStatuses = new ArrayList<>(20);
     private boolean allTestsDone;
     private boolean allTestsPassed;
     private String currentFailedInput;

--- a/code-runner/src/main/java/com/epam/coderunner/model/TestingStatusBuilder.java
+++ b/code-runner/src/main/java/com/epam/coderunner/model/TestingStatusBuilder.java
@@ -5,7 +5,7 @@ import com.google.common.base.Throwables;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class TestingStatusBuilder {
+public final class TestingStatusBuilder {
     private final Collection<Status> testsStatuses = new ArrayList<>(20);
     private boolean allTestsDone;
     private boolean allTestsPassed;

--- a/code-runner/src/main/java/com/epam/coderunner/runners/JavaCodeRunner.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/JavaCodeRunner.java
@@ -20,13 +20,13 @@ final class JavaCodeRunner implements CodeRunner {
     private final TaskExecutor taskExecutor;
     private final TaskStorage taskStorage;
     private final SourceCodeGuard sourceCodeGuard;
-    private final RuntimeCodeCompiler codeCompiler;
+    private final RuntimeCodeCompiler<Function<String, String>> codeCompiler;
 
     @Autowired
     JavaCodeRunner(final TaskExecutor taskExecutor,
                    final TaskStorage taskStorage,
                    final SourceCodeGuard sourceCodeGuard,
-                   final RuntimeCodeCompiler codeCompiler) {
+                   final RuntimeCodeCompiler<Function<String, String>> codeCompiler) {
         this.taskExecutor = taskExecutor;
         this.taskStorage = taskStorage;
         this.sourceCodeGuard = sourceCodeGuard;

--- a/code-runner/src/main/java/com/epam/coderunner/runners/JavaCodeRunner.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/JavaCodeRunner.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -44,8 +45,8 @@ final class JavaCodeRunner implements CodeRunner {
 
         try {
             final SourceCode checkedSource = sourceCodeGuard.proguard(sourceCode);
-            final Function<String, String> function = codeCompiler.compile(checkedSource);
-            compiledTask = new CompiledTask(userId, taskId, task.getAcceptanceTests(), function);
+            final Supplier<Function<String, String>> functionSupplier = codeCompiler.compile(checkedSource);
+            compiledTask = new CompiledTask(userId, taskId, task.getAcceptanceTests(), functionSupplier);
         } catch (final Exception e) {
             LOG.error("{}Error while preparing task:", signature, e);
             return Mono.just(TestingStatus.error(e));

--- a/code-runner/src/main/java/com/epam/coderunner/runners/JavaCodeRunner.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/JavaCodeRunner.java
@@ -41,9 +41,8 @@ final class JavaCodeRunner implements CodeRunner {
         final String signature = taskRequest.signature();
         LOG.debug("{}Begin to compile task source, source:\n{}", signature, sourceCode);
         final CompiledTask compiledTask;
-        final Task task = checkNotNull(taskStorage.getTask(taskId), "No task[id:%s] found", taskId);
-
         try {
+            final Task task = checkNotNull(taskStorage.getTask(taskId), "No task[id:%s] found", taskId);
             final SourceCode checkedSource = sourceCodeGuard.proguard(sourceCode);
             final Supplier<Function<String, String>> functionSupplier = codeCompiler.compile(checkedSource);
             compiledTask = new CompiledTask(userId, taskId, task.getAcceptanceTests(), functionSupplier);

--- a/code-runner/src/main/java/com/epam/coderunner/runners/JavaCodeRunner.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/JavaCodeRunner.java
@@ -20,13 +20,13 @@ final class JavaCodeRunner implements CodeRunner {
     private final TaskExecutor taskExecutor;
     private final TaskStorage taskStorage;
     private final SourceCodeGuard sourceCodeGuard;
-    private final RuntimeCodeCompiler<Function<String, String>> codeCompiler;
+    private final RuntimeCodeCompiler codeCompiler;
 
     @Autowired
     JavaCodeRunner(final TaskExecutor taskExecutor,
                    final TaskStorage taskStorage,
                    final SourceCodeGuard sourceCodeGuard,
-                   final RuntimeCodeCompiler<Function<String, String>> codeCompiler) {
+                   final RuntimeCodeCompiler codeCompiler) {
         this.taskExecutor = taskExecutor;
         this.taskStorage = taskStorage;
         this.sourceCodeGuard = sourceCodeGuard;

--- a/code-runner/src/main/java/com/epam/coderunner/runners/RuntimeCodeCompiler.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/RuntimeCodeCompiler.java
@@ -1,32 +1,37 @@
 package com.epam.coderunner.runners;
 
 import com.epam.coderunner.model.SourceCode;
+import com.epam.coderunner.support.RuntimeTypeCaptor;
+import com.google.common.reflect.TypeToken;
 import org.joor.Reflect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
+import java.util.function.Function;
 import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /** Unloading class seems unnecessary, see related pressure test. */
 @Component
-final class RuntimeCodeCompiler<T> {
+final class RuntimeCodeCompiler extends RuntimeTypeCaptor<Function<String, String>> {
     private static final Logger LOG = LoggerFactory.getLogger(RuntimeCodeCompiler.class);
 
-
-
     @SuppressWarnings("unchecked")
-    Supplier<T> compile(final SourceCode source) {
+    Supplier<Function<String, String>> compile(final SourceCode source) {
+        final TypeToken<Function<String, String>> type = getGenericType();
         try {
-            final Class<?> type = Reflect.compile(source.getClassName(), source.getCode())
+            final Class<?> clazz = Reflect.compile(source.getClassName(), source.getCode())
                     .create()
                     .type();
-            //checkArgument(type.equals(), "Source code super type[{}] is not a Function", type.getSuperclass()); todo
-            LOG.debug("SourceCode code has type of {}", Arrays.toString(type.getInterfaces()));
+            checkArgument(type.isSupertypeOf(clazz),
+                    "Source code type[%s] is not a sub type of %s", clazz, type);
+            LOG.debug("SourceCode code has type of {}", Arrays.toString(clazz.getInterfaces()));
             return () -> {
                 try {
-                    return (T) type.newInstance();
+                    return (Function<String, String>) clazz.newInstance();
                 } catch (final Exception e) {
                     LOG.error("Cannot create instance of function of type:{}, source:{}", type, source.getCode(), e);
                     throw new RuntimeException("Source type instance creation failed.", e);

--- a/code-runner/src/main/java/com/epam/coderunner/runners/RuntimeCodeCompiler.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/RuntimeCodeCompiler.java
@@ -4,15 +4,10 @@ import com.epam.coderunner.model.SourceCode;
 import org.joor.Reflect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
-import java.util.function.Function;
 import java.util.function.Supplier;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 /** Unloading class seems unnecessary, see related pressure test. */
 @Component

--- a/code-runner/src/main/java/com/epam/coderunner/runners/RuntimeCodeCompiler.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/RuntimeCodeCompiler.java
@@ -7,15 +7,40 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
 /** Unloading class seems unnecessary, see related pressure test. */
 @Component
-final class RuntimeCodeCompiler {
+final class RuntimeCodeCompiler<T> {
     private static final Logger LOG = LoggerFactory.getLogger(RuntimeCodeCompiler.class);
 
+
+
     @SuppressWarnings("unchecked")
-    <T> T compile(final SourceCode source) {
-        final Object obj = Reflect.compile(source.getClassName(), source.getCode()).create().get();
-        LOG.trace("SourceCode code has type of {}", obj.getClass());
-        return (T) obj;
+    Supplier<T> compile(final SourceCode source) {
+        try {
+            final Class<?> type = Reflect.compile(source.getClassName(), source.getCode())
+                    .create()
+                    .type();
+            //checkArgument(type.equals(), "Source code super type[{}] is not a Function", type.getSuperclass()); todo
+            LOG.debug("SourceCode code has type of {}", Arrays.toString(type.getInterfaces()));
+            return () -> {
+                try {
+                    return (T) type.newInstance();
+                } catch (final Exception e) {
+                    LOG.error("Cannot create instance of function of type:{}, source:{}", type, source.getCode(), e);
+                    throw new RuntimeException("Source type instance creation failed.", e);
+                }
+            };
+        } catch (final Exception e) {
+            LOG.error("Compile source code failed, error:", e);
+            throw new RuntimeException("Compile source code failed.", e);
+        }
+
     }
 }

--- a/code-runner/src/main/java/com/epam/coderunner/runners/RuntimeCodeCompiler.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/RuntimeCodeCompiler.java
@@ -17,19 +17,19 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 /** Unloading class seems unnecessary, see related pressure test. */
 @Component
-final class RuntimeCodeCompiler extends RuntimeTypeCaptor<Function<String, String>> {
+final class RuntimeCodeCompiler {
     private static final Logger LOG = LoggerFactory.getLogger(RuntimeCodeCompiler.class);
+    private final TypeToken<Function<String, String>> type = new TypeToken<Function<String, String>>() {};
 
     @SuppressWarnings("unchecked")
     Supplier<Function<String, String>> compile(final SourceCode source) {
-        final TypeToken<Function<String, String>> type = getGenericType();
         try {
             final Class<?> clazz = Reflect.compile(source.getClassName(), source.getCode())
                     .create()
                     .type();
             checkArgument(type.isSupertypeOf(clazz),
                     "Source code type[%s] is not a sub type of %s", clazz, type);
-            LOG.debug("Source code has type of {}", Arrays.toString(clazz.getInterfaces()));
+            LOG.debug("Source code[{}] has type of {}", source.getClassName(), Arrays.toString(clazz.getInterfaces()));
             checkArgument(Modifier.isPublic(clazz.getModifiers()),
                     "Source code class[%s] is not public.", clazz);
             return () -> {

--- a/code-runner/src/main/java/com/epam/coderunner/runners/RuntimeCodeCompiler.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/RuntimeCodeCompiler.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -28,7 +29,9 @@ final class RuntimeCodeCompiler extends RuntimeTypeCaptor<Function<String, Strin
                     .type();
             checkArgument(type.isSupertypeOf(clazz),
                     "Source code type[%s] is not a sub type of %s", clazz, type);
-            LOG.debug("SourceCode code has type of {}", Arrays.toString(clazz.getInterfaces()));
+            LOG.debug("Source code has type of {}", Arrays.toString(clazz.getInterfaces()));
+            checkArgument(Modifier.isPublic(clazz.getModifiers()),
+                    "Source code class[%s] is not public.", clazz);
             return () -> {
                 try {
                     return (Function<String, String>) clazz.newInstance();

--- a/code-runner/src/main/java/com/epam/coderunner/runners/SolutionChecker.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/SolutionChecker.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-import java.util.function.Function;
 
 final class SolutionChecker {
     private static final Logger LOG = LoggerFactory.getLogger(SolutionChecker.class);

--- a/code-runner/src/main/java/com/epam/coderunner/runners/SolutionChecker.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/SolutionChecker.java
@@ -17,7 +17,6 @@ final class SolutionChecker {
 
     static TestingStatus checkSolution(final CompiledTask compiledTask) {
         final Map<String, String> inputOutputs = compiledTask.getInputOutputs();
-        final Function<String, String> function = compiledTask.getFunction();
         final TestingStatusBuilder testingStatusBuilder = TestingStatus.builder();
         LOG.debug("{}Start testing task solution..", compiledTask.signature());
         try {
@@ -26,7 +25,7 @@ final class SolutionChecker {
                 final String input = entry.getKey();
                 final String expected = entry.getValue().trim();
                 LOG.debug("{}Start checking.., input[{}], expected[{}]", compiledTask.signature(), input, expected);
-                final String actual = function.apply(input).trim();
+                final String actual = compiledTask.getFunction().apply(input).trim();
                 if (!actual.equals(expected)) {
                     LOG.debug("{}Failed on test [{}]. Expected: [{}], actual: [{}]", compiledTask.signature(), input, expected, actual);
                     testingStatusBuilder.addStatus(Status.FAIL).setCurrentFailedInputIfAbsent(input);

--- a/code-runner/src/main/java/com/epam/coderunner/runners/SourceCodeGuard.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/SourceCodeGuard.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Component
 class SourceCodeGuard {
     private static final List<String> keywordBlacklist = readBlacklist();
+    //todo: add class public check
     private static final Pattern classNamePattern = Pattern.compile("(?s)(.*class\\s+)Solution[\\d]+(\\b.*)");
     private static final Pattern packageNamePattern = Pattern.compile("(?s)\\s*package\\s+[\\w.]+;(.*)");
     private static final AtomicLong classId = new AtomicLong(1000000);

--- a/code-runner/src/main/java/com/epam/coderunner/runners/SourceCodeGuard.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/SourceCodeGuard.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Component
 class SourceCodeGuard {
     private static final List<String> keywordBlacklist = readBlacklist();
-    //todo: add class public check
     private static final Pattern classNamePattern = Pattern.compile("(?s)(.*class\\s+)Solution[\\d]+(\\b.*)");
     private static final Pattern packageNamePattern = Pattern.compile("(?s)\\s*package\\s+[\\w.]+;(.*)");
     private static final AtomicLong classId = new AtomicLong(1000000);

--- a/code-runner/src/main/java/com/epam/coderunner/runners/SourceCodeGuard.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/SourceCodeGuard.java
@@ -4,7 +4,6 @@ import com.epam.coderunner.model.SourceCode;
 import com.google.common.io.Resources;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/code-runner/src/main/java/com/epam/coderunner/runners/TaskExecutorImpl.java
+++ b/code-runner/src/main/java/com/epam/coderunner/runners/TaskExecutorImpl.java
@@ -1,33 +1,41 @@
 package com.epam.coderunner.runners;
 
 import com.epam.coderunner.model.TestingStatus;
+import com.google.common.annotations.VisibleForTesting;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
-import javax.annotation.PreDestroy;
 import java.time.Duration;
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 @Service
 final class TaskExecutorImpl implements TaskExecutor {
 
     private final int taskTimeoutMs;
+    private final Supplier<Scheduler> schedulerSupplier;
 
+    @Autowired
     TaskExecutorImpl(@Value("${task.timeout}") final int taskTimeoutMs) {
         this.taskTimeoutMs = taskTimeoutMs;
+        this.schedulerSupplier = () -> Schedulers.newSingle("task-exec");
+    }
+
+    @VisibleForTesting
+    TaskExecutorImpl(final Supplier<Scheduler> schedulerSupplier){
+        this.taskTimeoutMs = 100;
+        this.schedulerSupplier = schedulerSupplier;
     }
 
     @Override
     public Mono<TestingStatus> submit(final Callable<TestingStatus> task) {
+        final Scheduler scheduler = schedulerSupplier.get();
         return Mono.fromCallable(task)
-                .publishOn(Schedulers.single())
+                .publishOn(scheduler).doFinally(st -> scheduler.dispose())
                 .timeout(Duration.ofMillis(taskTimeoutMs));
-    }
-
-    @PreDestroy
-    void dispose(){
-        Schedulers.single().dispose();
     }
 }

--- a/code-runner/src/main/java/com/epam/coderunner/storage/RedisTaskStorage.java
+++ b/code-runner/src/main/java/com/epam/coderunner/storage/RedisTaskStorage.java
@@ -1,6 +1,6 @@
 package com.epam.coderunner.storage;
 
-import com.epam.coderunner.InternalUtils;
+import com.epam.coderunner.support.InternalUtils;
 import com.epam.coderunner.model.Task;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;

--- a/code-runner/src/main/java/com/epam/coderunner/storage/RedisTaskStorage.java
+++ b/code-runner/src/main/java/com/epam/coderunner/storage/RedisTaskStorage.java
@@ -6,13 +6,15 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.annotation.*;
 import org.springframework.stereotype.Service;
 import redis.clients.jedis.Jedis;
 
+import javax.annotation.PreDestroy;
+
 @Service
 @EnableCaching
+@CacheConfig(cacheNames = "taskCache")
 class RedisTaskStorage implements TaskStorage {
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisTaskStorage.class);
@@ -24,15 +26,22 @@ class RedisTaskStorage implements TaskStorage {
         jedis = new Jedis(redisHost);
     }
 
-    @Cacheable("task")
+    @PreDestroy
+    private void close(){
+        jedis.close();
+    }
+
+    @Cacheable
     @Override
-    public Task getTask(final long taskId){
+    public synchronized Task getTask(final long taskId){
         return InternalUtils.fromJson(jedis.get("task:"+taskId), Task.class);
     }
 
     @VisibleForTesting
+    @CachePut(key = "#taskId")
     @Override
-    public void saveTask(final long taskId, final Task task) {
+    public synchronized Task saveTask(final long taskId, final Task task) {
         jedis.set("task:"+ taskId, InternalUtils.toJson(task));
+        return task;
     }
 }

--- a/code-runner/src/main/java/com/epam/coderunner/storage/TaskStorage.java
+++ b/code-runner/src/main/java/com/epam/coderunner/storage/TaskStorage.java
@@ -8,5 +8,5 @@ public interface TaskStorage {
     Task getTask(final long taskId);
 
     @VisibleForTesting
-    void saveTask(final long taskId, final Task task);
+    Task saveTask(final long taskId, final Task task);
 }

--- a/code-runner/src/main/java/com/epam/coderunner/support/InternalUtils.java
+++ b/code-runner/src/main/java/com/epam/coderunner/support/InternalUtils.java
@@ -1,9 +1,11 @@
-package com.epam.coderunner;
+package com.epam.coderunner.support;
 
 import com.google.gson.Gson;
 
 public final class InternalUtils {
     private static final Gson gson = new Gson();
+
+    public static String NEWLINE = System.lineSeparator();
 
     private InternalUtils(){}
 

--- a/code-runner/src/main/java/com/epam/coderunner/support/RuntimeTypeCaptor.java
+++ b/code-runner/src/main/java/com/epam/coderunner/support/RuntimeTypeCaptor.java
@@ -1,0 +1,17 @@
+package com.epam.coderunner.support;
+
+import com.google.common.reflect.TypeToken;
+
+/**
+ * Extends this class with reified type parameter to capture the type for subclass to use.<br>
+ * Note: It will not work, if one extends this class still with generic type.
+ *
+ * @param <T> type parameter to capture
+ */
+public abstract class RuntimeTypeCaptor<T> {
+    private final TypeToken<T> typeToken = new TypeToken<T>(getClass()) {};
+
+    protected final TypeToken<T> getGenericType() {
+        return typeToken;
+    }
+}

--- a/code-runner/src/test/java/com/epam/coderunner/CodeRunnerApplicationTests.java
+++ b/code-runner/src/test/java/com/epam/coderunner/CodeRunnerApplicationTests.java
@@ -3,6 +3,7 @@ package com.epam.coderunner;
 import com.epam.coderunner.model.Task;
 import com.epam.coderunner.model.TestingStatus;
 import com.epam.coderunner.storage.TaskStorage;
+import com.epam.coderunner.support.InternalUtils;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.AfterClass;
@@ -26,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
 
-import static com.epam.coderunner.model.Status.FAIL;
 import static com.epam.coderunner.model.Status.PASS;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/code-runner/src/test/java/com/epam/coderunner/CodeRunnerApplicationTests.java
+++ b/code-runner/src/test/java/com/epam/coderunner/CodeRunnerApplicationTests.java
@@ -76,7 +76,7 @@ public class CodeRunnerApplicationTests {
         LOG.info("Response specs:{}", response);
         final TestingStatus testingStatus = TestingStatus.fromJson(response);
 
-        assertThat(testingStatus.getTestsStatuses()).containsExactly(FAIL, PASS);
+        assertThat(testingStatus.getTestsStatuses()).containsExactly(PASS, PASS);
     }
 
     @Test

--- a/code-runner/src/test/java/com/epam/coderunner/CodeRunnerApplicationTests.java
+++ b/code-runner/src/test/java/com/epam/coderunner/CodeRunnerApplicationTests.java
@@ -1,6 +1,7 @@
 package com.epam.coderunner;
 
 import com.epam.coderunner.model.Task;
+import com.epam.coderunner.model.TaskRequest;
 import com.epam.coderunner.model.TestingStatus;
 import com.epam.coderunner.storage.TaskStorage;
 import com.epam.coderunner.support.InternalUtils;
@@ -23,10 +24,12 @@ import reactor.core.publisher.Flux;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
 
+import static com.epam.coderunner.model.Status.FAIL;
 import static com.epam.coderunner.model.Status.PASS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,15 +51,14 @@ public class CodeRunnerApplicationTests {
     @Before
     public void setup() {
         for (int i = 0; i < 5; i++) {
-            if (taskStorage.getTask(i) == null) {
-                final Map<String, String> inOut = ImmutableMap.of(
-                        "1", "1",
-                        "21", "21"
-                );
-                final Task task = new Task();
-                task.setAcceptanceTests(inOut);
-                taskStorage.saveTask(i, task);
-            }
+            final Map<String, String> inOut = ImmutableMap.of(
+                    "1,2,3", "6",
+                    "21", "21",
+                    "1,4", "3"
+            );
+            final Task task = new Task();
+            task.setAcceptanceTests(inOut);
+            taskStorage.saveTask(i, task);
         }
     }
 
@@ -76,7 +78,7 @@ public class CodeRunnerApplicationTests {
         LOG.info("Response specs:{}", response);
         final TestingStatus testingStatus = TestingStatus.fromJson(response);
 
-        assertThat(testingStatus.getTestsStatuses()).containsExactly(PASS, PASS);
+        assertThat(testingStatus.getTestsStatuses()).containsExactly(PASS, PASS, FAIL);
     }
 
     @Test
@@ -96,24 +98,32 @@ public class CodeRunnerApplicationTests {
 
     @Test
     public void longRunningTaskPressureTesting() {
-        final List<Future<Flux<String>>> futures = new ArrayList<>(20);
-        for (int i = 0; i < 20; i++) {
-            futures.add(
+        final ThreadLocalRandom random = ThreadLocalRandom.current();
+        final Map<Long, Future<String>> futures = new HashMap<>(20);
+        for (int i = 0; i < 10; i++) {
+            final TaskRequest request = TestData.readTaskFromResources(random.nextInt(1,3));
+            futures.put(
+                    request.getTaskId(),
                     executor.submit(() -> webTestClient
                             .post().uri("task/submit")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .body(BodyInserters.fromObject(InternalUtils.toJson(TestData.readTaskFromResources(2))))
-                            .exchange()
-                            .returnResult(String.class).getResponseBody()
+                            .body(BodyInserters.fromObject(InternalUtils.toJson(request)))
+                            .exchange().expectStatus().is2xxSuccessful()
+                            .expectBody(String.class).returnResult().getResponseBody()
                     )
             );
         }
         LOG.debug("All requests fired!");
-        futures.forEach(f -> {
+        futures.forEach((index, future )-> {
             try {
-                final String response = f.get().blockFirst(Duration.ofSeconds(3));
+                final String response = future.get();
+                LOG.debug("Response:{}", response);
                 final TestingStatus testingStatus = TestingStatus.fromJson(response);
-                assertThat(testingStatus.getErrorType()).isEqualTo(TimeoutException.class.getName());
+                if(index == 2){
+                    assertThat(testingStatus.getErrorType()).isEqualTo(TimeoutException.class.getName());
+                }else if(index == 1){
+                    assertThat(testingStatus.getErrorType()).isNullOrEmpty();
+                }
             } catch (InterruptedException | ExecutionException e) {
                 throw new RuntimeException(e);
             }

--- a/code-runner/src/test/java/com/epam/coderunner/CodeRunnerApplicationTests.java
+++ b/code-runner/src/test/java/com/epam/coderunner/CodeRunnerApplicationTests.java
@@ -100,8 +100,8 @@ public class CodeRunnerApplicationTests {
     public void longRunningTaskPressureTesting() {
         final ThreadLocalRandom random = ThreadLocalRandom.current();
         final Map<Long, Future<String>> futures = new HashMap<>(20);
-        for (int i = 0; i < 10; i++) {
-            final TaskRequest request = TestData.readTaskFromResources(random.nextInt(1,3));
+        for (int i = 0; i < 20; i++) {
+            final TaskRequest request = TestData.readTaskFromResources(random.nextInt(1, 3));
             futures.put(
                     request.getTaskId(),
                     executor.submit(() -> webTestClient
@@ -114,14 +114,14 @@ public class CodeRunnerApplicationTests {
             );
         }
         LOG.debug("All requests fired!");
-        futures.forEach((index, future )-> {
+        futures.forEach((index, future) -> {
             try {
                 final String response = future.get();
                 LOG.debug("Response:{}", response);
                 final TestingStatus testingStatus = TestingStatus.fromJson(response);
-                if(index == 2){
+                if (index == 2) {
                     assertThat(testingStatus.getErrorType()).isEqualTo(TimeoutException.class.getName());
-                }else if(index == 1){
+                } else if (index == 1) {
                     assertThat(testingStatus.getErrorType()).isNullOrEmpty();
                 }
             } catch (InterruptedException | ExecutionException e) {

--- a/code-runner/src/test/java/com/epam/coderunner/runners/JavaCodeRunnerTest.java
+++ b/code-runner/src/test/java/com/epam/coderunner/runners/JavaCodeRunnerTest.java
@@ -36,7 +36,7 @@ public final class JavaCodeRunnerTest {
     private final TaskStorage taskStorage = mock(TaskStorage.class);
     private final TaskExecutor taskExecutor = mock(TaskExecutor.class);
     private final JavaCodeRunner testee =
-            new JavaCodeRunner(taskExecutor, taskStorage, new SourceCodeGuard(), new RuntimeCodeCompiler<>());
+            new JavaCodeRunner(taskExecutor, taskStorage, new SourceCodeGuard(), new RuntimeCodeCompiler());
 
     @Before
     public void setup(){

--- a/code-runner/src/test/java/com/epam/coderunner/runners/JavaCodeRunnerTest.java
+++ b/code-runner/src/test/java/com/epam/coderunner/runners/JavaCodeRunnerTest.java
@@ -36,7 +36,7 @@ public final class JavaCodeRunnerTest {
     private final TaskStorage taskStorage = mock(TaskStorage.class);
     private final TaskExecutor taskExecutor = mock(TaskExecutor.class);
     private final JavaCodeRunner testee =
-            new JavaCodeRunner(taskExecutor, taskStorage, new SourceCodeGuard(), new RuntimeCodeCompiler());
+            new JavaCodeRunner(taskExecutor, taskStorage, new SourceCodeGuard(), new RuntimeCodeCompiler<>());
 
     @Before
     public void setup(){

--- a/code-runner/src/test/java/com/epam/coderunner/runners/RuntimeCodeCompilerTest.java
+++ b/code-runner/src/test/java/com/epam/coderunner/runners/RuntimeCodeCompilerTest.java
@@ -10,10 +10,9 @@ import org.junit.rules.ExpectedException;
 
 import java.util.function.Function;
 
-
 public final class RuntimeCodeCompilerTest {
 
-    private final RuntimeCodeCompiler<Function<String, String>> codeCompiler = new RuntimeCodeCompiler<>();
+    private final RuntimeCodeCompiler codeCompiler = new RuntimeCodeCompiler();
 
     @Before
     public void setup() {
@@ -43,5 +42,17 @@ public final class RuntimeCodeCompilerTest {
             final Function<String, String> function = codeCompiler.compile(sourceCode).get();
             function.apply("1324");
         }
+    }
+
+    @Test
+    public void sourceCodeWithWrongType(){
+        final String source = new StringBuilder()
+                .append("public class BadType implements java.util.function.Supplier<String>{")
+                .append("  public String get(){")
+                .append("    return \"someValue\";")
+                .append("  }")
+                .append("}").toString();
+        thrown.expectCause(Matchers.any(IllegalArgumentException.class));
+        codeCompiler.compile(new SourceCode("BadType", source));
     }
 }

--- a/code-runner/src/test/java/com/epam/coderunner/runners/RuntimeCodeCompilerTest.java
+++ b/code-runner/src/test/java/com/epam/coderunner/runners/RuntimeCodeCompilerTest.java
@@ -2,6 +2,8 @@ package com.epam.coderunner.runners;
 
 import com.epam.coderunner.TestData;
 import com.epam.coderunner.model.SourceCode;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,5 +56,22 @@ public final class RuntimeCodeCompilerTest {
                 .append("}").toString();
         thrown.expectCause(Matchers.any(IllegalArgumentException.class));
         codeCompiler.compile(new SourceCode("BadType", source));
+    }
+
+    @Test
+    public void classMustBePublic(){ //class.newInstance() is called
+        final String source = new StringBuilder()
+                .append("class NonPublicClazz implements java.util.function.Function<String, String>{")
+                .append("public String apply(String input){return input;}")
+                .append("}").toString();
+        thrown.expectCause(new BaseMatcher<Throwable>() {
+
+            @Override public void describeTo(final Description description) {}
+            @Override public boolean matches(final Object item) {
+                final IllegalArgumentException exception = (IllegalArgumentException) item;
+                return exception.getMessage().contains("is not public");
+            }
+        });
+        codeCompiler.compile(new SourceCode("NonPublicClazz", source));
     }
 }

--- a/code-runner/src/test/java/com/epam/coderunner/runners/RuntimeCodeCompilerTest.java
+++ b/code-runner/src/test/java/com/epam/coderunner/runners/RuntimeCodeCompilerTest.java
@@ -2,6 +2,7 @@ package com.epam.coderunner.runners;
 
 import com.epam.coderunner.TestData;
 import com.epam.coderunner.model.SourceCode;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -9,36 +10,38 @@ import org.junit.rules.ExpectedException;
 
 import java.util.function.Function;
 
+
 public final class RuntimeCodeCompilerTest {
 
-    private final RuntimeCodeCompiler codeCompiler = new RuntimeCodeCompiler();
+    private final RuntimeCodeCompiler<Function<String, String>> codeCompiler = new RuntimeCodeCompiler<>();
 
     @Before
-    public void setup(){
+    public void setup() {
 
     }
 
     @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void compileWithPackage(){
+    public void compileWithPackage() {
         final String source = TestData.readTaskFromResources(3).getSource();
         codeCompiler.compile(new SourceCode("com.github.someone.Solution3", source));
     }
 
     @Test
     public void badSourceCode() {
-        thrown.expect(org.joor.ReflectException.class);
-        codeCompiler.compile(new SourceCode("SomeClass","bullshit"));
+        thrown.expectCause(Matchers.any(org.joor.ReflectException.class));
+        codeCompiler.compile(new SourceCode("SomeClass", "bullshit"));
     }
 
     @Test
-    public void classLoadingPressureTesting(){
+    public void classLoadingPressureTesting() {
         final String source = TestData.readTaskFromResources(1).getSource();
 
         for (int i = 0; i < 100000; i++) {
-           final Function<String, String> function = codeCompiler.compile(new SourceCode("Solution1", source));
-           function.apply("someInput");
+            final SourceCode sourceCode = new SourceCode("Solution1", source);
+            final Function<String, String> function = codeCompiler.compile(sourceCode).get();
+            function.apply("1324");
         }
     }
 }

--- a/code-runner/src/test/java/com/epam/coderunner/runners/TaskExecutorImplTest.java
+++ b/code-runner/src/test/java/com/epam/coderunner/runners/TaskExecutorImplTest.java
@@ -36,6 +36,7 @@ public class TaskExecutorImplTest {
     @Test
     public void timeoutTaskShouldBeCanceled() {
         final Callable<TestingStatus> task = () -> {
+            //noinspection InfiniteLoopStatement
             while (true) {}
         };
 

--- a/code-runner/src/test/java/com/epam/coderunner/runners/TaskExecutorImplTest.java
+++ b/code-runner/src/test/java/com/epam/coderunner/runners/TaskExecutorImplTest.java
@@ -2,23 +2,44 @@ package com.epam.coderunner.runners;
 
 import com.epam.coderunner.model.Status;
 import com.epam.coderunner.model.TestingStatus;
-import org.junit.AfterClass;
+import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
+import java.util.Queue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaskExecutorImplTest {
+public final class TaskExecutorImplTest {
+    private static final Logger LOG = LoggerFactory.getLogger(TaskExecutorImplTest.class);
 
-    private static final TaskExecutorImpl taskExecutor = new TaskExecutorImpl(1000);
+    private static final AtomicInteger counter = new AtomicInteger();
+    private final Queue<Scheduler> schedulerWatched = new ConcurrentLinkedQueue<>();
+    private final TaskExecutor taskExecutor = new TaskExecutorImpl(() -> {
+        final Scheduler scheduler = Schedulers.newSingle("test-exec" + counter.getAndIncrement());
+        schedulerWatched.offer(scheduler);
+        return scheduler;
+    });
 
-    @AfterClass
-    public static void dispose() {
-        taskExecutor.dispose();
+    @After
+    public void checkSchedulers(){
+        schedulerWatched.forEach(scheduler -> {
+            Awaitility.waitAtMost(3, TimeUnit.SECONDS).until(scheduler::isDisposed);
+            LOG.debug("Scheduler[{}] has been successfully disposed", scheduler);
+        });
+        System.out.println("------------------------------");
     }
 
     @Test
@@ -26,26 +47,36 @@ public class TaskExecutorImplTest {
         final TestingStatus testingStatus = TestingStatus.builder()
                 .addStatus(Status.FAIL)
                 .setCurrentFailedInputIfAbsent("someInput").build();
-        final Callable<TestingStatus> task = () -> testingStatus;
+        final Callable<TestingStatus> task = () -> {
+            LOG.debug("Start to executing simple task...");
+            return testingStatus;
+        };
         final TestingStatus result = taskExecutor.submit(task).block(Duration.ofSeconds(1));
         assertThat(result).isEqualTo(testingStatus);
+        LOG.debug("Simple task executed and returned with success.");
     }
 
-    @Rule public ExpectedException thrown = ExpectedException.none();
-
     @Test
-    public void timeoutTaskShouldBeCanceled() {
-        final Callable<TestingStatus> task = () -> {
+    public void timeoutTaskShouldHasItsWorkerDisposed() {
+        final Callable<TestingStatus> badTask = () -> {
+            LOG.debug("Start to executing infinite loop...");
             //noinspection InfiniteLoopStatement
             while (true) {}
         };
-
-        thrown.expectMessage("Timeout");
-        taskExecutor.submit(task).block(Duration.ofSeconds(1));
+        try{
+            taskExecutor.submit(badTask).block(Duration.ofSeconds(1));
+            throw new AssertionError("Test failed, no exception thrown.");
+        }catch (final Exception e){
+            assertThat(e).describedAs("Actual exception:%s", e).hasCauseInstanceOf(TimeoutException.class);
+        }
+        LOG.debug("After failed task, try to test another pass through task...");
+        passThrough();
+        LOG.debug("Subsequent task executed successfully.");
     }
 
+    @Rule public ExpectedException thrown = ExpectedException.none();
     @Test
-    public void errorThrown() {
+    public void throwStackOverflowError() {
         final Callable<TestingStatus> task = this::infiniteRecursion;
         thrown.expectMessage("TimeoutException");
         taskExecutor.submit(task).block(Duration.ofSeconds(2));

--- a/code-runner/src/test/resources/Solution1.java
+++ b/code-runner/src/test/resources/Solution1.java
@@ -1,7 +1,7 @@
 import java.util.Arrays;
 import java.util.function.Function;
 
-final class Solution1 implements Function<String, String> {
+public class Solution1 implements Function<String, String> {
 
     @Override
     public String apply(String s) {

--- a/code-runner/src/test/resources/Solution1.java
+++ b/code-runner/src/test/resources/Solution1.java
@@ -3,8 +3,13 @@ import java.util.function.Function;
 
 public class Solution1 implements Function<String, String> {
 
+    private int state = 0;
+
     @Override
     public String apply(String s) {
-        return Arrays.stream(s.split(",")).map(str-> Integer.parseInt(str)).reduce((l, r) -> l+r).get() + "";
+        int sum = Arrays.stream(s.split(",")).map(Integer::parseInt).reduce(0, Integer::sum);
+        sum = sum + state;
+        state++;
+        return String.valueOf(sum);
     }
 }

--- a/code-runner/src/test/resources/logback-test.xml
+++ b/code-runner/src/test/resources/logback-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+	<layout class="ch.qos.logback.classic.PatternLayout">
+	  <Pattern>
+		%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+	  </Pattern>
+	</layout>
+  </appender>
+
+  <logger name="com.epam.coderunner.runners.RuntimeCodeCompiler" level="INFO" additivity="false">
+	<appender-ref ref="STDOUT" />
+  </logger>
+
+  <logger name="com.epam.coderunner" level="DEBUG" additivity="false">
+	<appender-ref ref="STDOUT" />
+  </logger>
+
+  <root level="INFO">
+	<appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>


### PR DESCRIPTION
1. Support stateful solution class. Now a new instance is created to apply to every task input.
2. Dead thread bug fixed. A failed task could leave a dead Scheduler, which leads to further TimeoutException. Now a new Scheduler is created for every task submitted, and disposed of after execution.
3. Socket error triggered by Redis connection should be fixed. Only one Jedis instance is used ever, now, synchronization is adopted alongside with Cache to better protect it.