### PR TITLE
Task exec thread pool

### DIFF
--- a/code-runner/src/test/java/com/epam/coderunner/runners/TaskExecutorImplTest.java
+++ b/code-runner/src/test/java/com/epam/coderunner/runners/TaskExecutorImplTest.java
@@ -2,43 +2,26 @@ package com.epam.coderunner.runners;
 
 import com.epam.coderunner.model.Status;
 import com.epam.coderunner.model.TestingStatus;
-import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
-import java.util.Queue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class TaskExecutorImplTest {
     private static final Logger LOG = LoggerFactory.getLogger(TaskExecutorImplTest.class);
 
-    private static final AtomicInteger counter = new AtomicInteger();
-    private final Queue<Scheduler> schedulerWatched = new ConcurrentLinkedQueue<>();
-    private final TaskExecutor taskExecutor = new TaskExecutorImpl(() -> {
-        final Scheduler scheduler = Schedulers.newSingle("test-exec" + counter.getAndIncrement());
-        schedulerWatched.offer(scheduler);
-        return scheduler;
-    });
+    private final TaskExecutor taskExecutor = new TaskExecutorImpl(100);
 
     @After
     public void checkSchedulers(){
-        schedulerWatched.forEach(scheduler -> {
-            Awaitility.waitAtMost(3, TimeUnit.SECONDS).until(scheduler::isDisposed);
-            LOG.debug("Scheduler[{}] has been successfully disposed", scheduler);
-        });
         System.out.println("------------------------------");
     }
 

--- a/code-runner/src/test/resources/Solution3.java
+++ b/code-runner/src/test/resources/Solution3.java
@@ -8,4 +8,8 @@ public class Solution3 implements Function<String, String> {
     public String apply(String s) {
         return "with-package";
     }
+
+    public static void main(String[] args){
+        throw new AssertionError("This should not be touched!");
+    }
 }


### PR DESCRIPTION
This PR removes the unnecessary scheduler creation, simply use an elastic scheduler.

When a fixed thread pool is used, from the pool's point of view, all works properly: when all threads are busy, a new coming task is queued. But from a request's point of view, it's waiting, no matter the task is being executed or queued. Thus a `TimoutException`.

Rather than manually creating scheduler, an elastic scheduler can be simply used. As of now, a bound on thread count is not needed.